### PR TITLE
Added numba as a requirement so Travis CI runs. Minor updates.

### DIFF
--- a/examples/CNO/burn.py
+++ b/examples/CNO/burn.py
@@ -26,15 +26,22 @@ def burn(Y0, rho, T, tmax, nsave):
     O14_out = []
     O15_out = []
 
-    while r.successful() and r.t < tmax:
-        print(r.t, r.y[cno.ip], r.y[cno.io14])
-        r.integrate(r.t+dt)
+    print(t, Y0[cno.ip], Y0[cno.io14])
 
-        t_out.append(r.t)
-        H_out.append(r.y[cno.ip])
-        He_out.append(r.y[cno.ihe4])
-        O14_out.append(r.y[cno.io14])
-        O15_out.append(r.y[cno.io15])
+    istep = 1
+    while r.successful() and istep <= nsave:
+        r.integrate(t+dt*istep)
+
+        if r.successful():
+            print(r.t, r.y[cno.ip], r.y[cno.io14])
+            t_out.append(r.t)
+            H_out.append(r.y[cno.ip])
+            He_out.append(r.y[cno.ihe4])
+            O14_out.append(r.y[cno.io14])
+            O15_out.append(r.y[cno.io15])
+            istep = istep + 1
+        else:
+            print("An integration error occurred at time {}".format(r.t))
 
     return t_out, H_out, He_out, O14_out, O15_out
 
@@ -57,6 +64,7 @@ if __name__ == "__main__":
     Ydot = cno.rhs(0.0, Y0, rho, T)
 
     tmax = 10.0*np.abs(Y0[cno.ip]/Ydot[cno.ip])
+    print("tmax: {}".format(tmax))
 
     nsteps = 100
 

--- a/pynucastro/rates/rate.py
+++ b/pynucastro/rates/rate.py
@@ -31,12 +31,12 @@ def list_known_rates():
 import numba
 
 Tfactor_spec = [
-('T9', numba.float32),
-('T9i', numba.float32),
-('T913', numba.float32),
-('T913i', numba.float32),
-('T953', numba.float32),
-('lnT9', numba.float32)
+('T9', numba.float64),
+('T9i', numba.float64),
+('T913', numba.float64),
+('T913i', numba.float64),
+('T953', numba.float64),
+('lnT9', numba.float64)
 ]
 
 @numba.jitclass(Tfactor_spec)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ nbsphinx>=0.3.1
 pytest>=3.2.1
 nbval>=0.9.0
 pytest-cov>=2.5.1
+numba>=0.40


### PR DESCRIPTION
Thanks so much for implementing numba support!

This is just some minor tweaks to allow Travis CI to run and fix a bug in our burn loop where it was possible to do an extra burn past the end time.

Also switches the Tfactors spec to use `numba.float64` for double precision to fix minor differences in the output for the CNO example at the O(1.e-8) level.
